### PR TITLE
Fix error message for wrong output size

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ Sha512.prototype.digest = function (enc, offset = 0) {
   }
 
   assert(enc instanceof Uint8Array, 'input must be Uint8Array or Buffer')
-  assert(enc.byteLength >= this.digestLength + offset, 'input must be Uint8Array or Buffer')
+  assert(enc.byteLength >= this.digestLength + offset, `input must be at least ${this.digestLength + offset} bytes`)
 
   for (let i = 0; i < this.digestLength; i++) {
     enc[i + offset] = resultBuf[i]


### PR DESCRIPTION
I bumped into this error and was very confused about how I could've
passed in anything other than a Uint8Array. After looking at the code
that was throwing the error, I think the error message is wrong.

This commit changes the error message so that it announces the size of
the array that it needs.