### PR TITLE
added better error handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -106,13 +106,17 @@ Sha512.WASM = wasm && wasm.buffer
 Sha512.WASM_SUPPORTED = typeof WebAssembly !== 'undefined'
 
 Sha512.ready = function (cb) {
-  if (!cb) cb = noop
   if (!wasm) return cb(new Error('WebAssembly not supported'))
+
+  if (cb) {
+    wasm.onload(cb)
+    return
+  }
 
   var p = new Promise(function (reject, resolve) {
     wasm.onload(function (err) {
-      if (err) resolve(err)
-      else reject()
+      if (err) reject(err)
+      else resolve()
       cb(err)
     })
   })

--- a/sha512.js
+++ b/sha512.js
@@ -28,12 +28,12 @@ function loadWebAssembly (opts) {
   }
 
   function onload (cb) {
-    if (mod.exports) return cb()
-
     if (ready) {
       ready.then(cb.bind(null, null)).catch(cb)
       return
     }
+
+    if (mod.exports) return cb()
 
     try {
       if (opts && opts.async) throw new Error('async')

--- a/test.js
+++ b/test.js
@@ -1,2 +1,15 @@
 const sha512 = require('./')
+const test = require('tape')
+
 require('sha-test').sha512(sha512)
+
+test('pass error argument if ready callback fail', t => {
+  const wasm = require('./sha512.js')({
+    imports: null // importing null will generate an error
+  })
+
+  wasm.onload(err => {
+    t.ok(err)
+    t.end()
+  })
+})


### PR DESCRIPTION
Hi @chm-diederichs, how are you?

We are trying to use sha512-universal in safari ios and for some reason (related with ios because) we got an error in sha512-wasm, the line: https://github.com/chm-diederichs/sha512-wasm/blob/master/sha512.js#L50

The wasm memory buffer is detached and the wasm loader throws an unhandled error and for that reason the sha512-universal cannot switch to the javascript fallback version.

1. I change the code to catch the errors on the instantiation wasm module + the setup process.
2. I change the ready method to support callback or promises but not both at the same time. And also I switch how it handles the result inside the promise. `resolve` to be the success case and `reject` to be error case.

Sorry for my english and if you have any comments we can discuss what I did here :) 

Thank you for your work on this!!