### PR TITLE
Check if `WebAssembly` is defined before importing WASM

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const assert = require('nanoassert')
 const b4a = require('b4a')
 
-const wasm = typeof WebAseembly !== 'undefined' && require('./sha512.js')({
+const wasm = typeof WebAssembly !== 'undefined' && require('./sha512.js')({
   imports: {
     debug: {
       log (...args) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const assert = require('nanoassert')
 const b4a = require('b4a')
 
-const wasm = require('./sha512.js')({
+const wasm = typeof WebAseembly !== 'undefined' && require('./sha512.js')({
   imports: {
     debug: {
       log (...args) {


### PR DESCRIPTION
This popped up while running `sodium-javascript` under Hermes.